### PR TITLE
update to Anima 0.3.0

### DIFF
--- a/attribs.gemspec
+++ b/attribs.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.extra_rdoc_files = %w[README.md]
 
-  gem.add_runtime_dependency "anima", "~> 0.2.0"
+  gem.add_runtime_dependency "anima", "~> 0.3.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3.1"

--- a/spec/attribs_spec.rb
+++ b/spec/attribs_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Attribs do
       end
 
       it 'should expect all attributes' do
-        expect { subject.new(foo: 5) }.to raise_exception(Anima::Error::Missing)
+        expect { subject.new(foo: 5) }.to raise_exception(Anima::Error, /missing: \[:bar\], unknown: \[\]/)
       end
     end
   end
@@ -99,7 +99,7 @@ RSpec.describe Attribs do
       end
 
       it 'should expect all attributes' do
-        expect { subject.new(foo: 5, bar: 6) }.to raise_exception(Anima::Error::Missing)
+        expect { subject.new(foo: 5, bar: 6) }.to raise_exception(Anima::Error, /missing: \[:bax\], unknown: \[\]/)
       end
     end
   end
@@ -113,7 +113,7 @@ RSpec.describe Attribs do
       end
 
       it 'should no longer recognize the old attributes' do
-        expect { subject.new(foo: 3, bar: 3).bar }.to raise_error(Anima::Error::Unknown)
+        expect { subject.new(foo: 3, bar: 3).bar }.to raise_exception(Anima::Error, /missing: \[\], unknown: \[:bar\]/)
       end
     end
 
@@ -125,7 +125,7 @@ RSpec.describe Attribs do
       end
 
       it 'should no longer recognize the old attributes' do
-        expect { subject.new(foo: 3).foo }.to raise_error(Anima::Error::Unknown)
+        expect { subject.new(foo: 3).foo }.to raise_exception(Anima::Error, /missing: \[\], unknown: \[:foo\]/)
       end
 
       it 'should keep the defaults' do


### PR DESCRIPTION
for compatibility with other projects. Actually, nothing really changed at attribs' code.
So maybe it's even possible to simply declare very optimistic `"anima", "~> 0.2", ">= 0.2.0"` or more pessimistic `"anima", "~> 0.2", "<= 0.4.0"` and try to make the spec aware of the different error classes.